### PR TITLE
[Backend] Add float&double low instructions

### DIFF
--- a/nnvm/Backend/RISCV/LowIR.cpp
+++ b/nnvm/Backend/RISCV/LowIR.cpp
@@ -54,6 +54,10 @@ void LowInst::emit(std::ostream &out, EmitInfo &info) const {
   case LW:
   case LD:
   case JALR:
+  case FLW:
+  case FSW:
+  case FLD:
+  case FSD:
     out << getNameForInstType(type) << " ";
     operand[0].emit(out, info);
     out << ", ";

--- a/nnvm/Backend/RISCV/LowInstType.h
+++ b/nnvm/Backend/RISCV/LowInstType.h
@@ -3,21 +3,39 @@
 #include <Utils/Debug.h>
 #include <cstdint>
 #include <unordered_map>
+#include <regex>
 
 #define MAKE_RFORMAT(GEN)                                                      \
   GEN(ADD), GEN(ADDW), GEN(SUB), GEN(SUBW), GEN(MUL), GEN(MULW), GEN(MULH),    \
       GEN(MULHSU), GEN(MULHU), GEN(DIV), GEN(DIVW), GEN(DIVU), GEN(DIVUW),     \
       GEN(REM), GEN(REMW), GEN(REMU), GEN(REMUW), GEN(SLL), GEN(SLLW),         \
       GEN(SLT), GEN(SLTU), GEN(XOR), GEN(SRL), GEN(SRLW), GEN(SRA), GEN(SRAW), \
-      GEN(OR), GEN(AND)
+      GEN(OR), GEN(AND),                                                       \
+      GEN(FADD_S), GEN(FSUB_S), GEN(FMUL_S), GEN(FDIV_S), GEN(FSQRT_S),        \
+      GEN(FMADD_S), GEN(FMSUB_S), GEN(FNMADD_S), GEN(FNMSUB_S),                \
+      GEN(FMIN_S), GEN(FMAX_S), GEN(FCVT_W_S), GEN(FCVT_L_S),                  \
+      GEN(FCVT_S_W), GEN(FCVT_S_L), GEN(FCVT_WU_S), GEN(FCVT_LU_S),            \
+      GEN(FCVT_S_WU), GEN(FCVT_S_LU), GEN(FSGNJ_S), GEN(FSGNJN_S),             \
+      GEN(FSGNJX_S), GEN(FMV_X_W), GEN(FMV_W_X), GEN(FMV_X_S), GEN(FMV_S_X),   \
+      GEN(FEQ_S), GEN(FLT_S), GEN(FLE_S), GEN(FCLASS_S),                       \
+      GEN(FADD), GEN(FSUB), GEN(FMUL), GEN(FDIV), GEN(FSQRT),                  \
+      GEN(FMADD), GEN(FMSUB), GEN(FNMADD), GEN(FNMSUB),                        \
+      GEN(FMIN), GEN(FMAX), GEN(FCVT_W_D), GEN(FCVT_L_D),                      \
+      GEN(FCVT_D_W), GEN(FCVT_D_L), GEN(FCVT_WU_D), GEN(FCVT_LU_D),            \
+      GEN(FCVT_D_WU), GEN(FCVT_D_LU), GEN(FCVT_S_D), GEN(FCVT_D_S),            \
+      GEN(FSGNJ_D), GEN(FSGNJN_D), GEN(FSGNJX_D), GEN(FMV_X_D), GEN(FMV_D_X),  \
+      GEN(FEQ_D), GEN(FLT_D), GEN(FLE_D), GEN(FCLASS_D)
 
 #define MAKE_IFORMAT(GEN)                                                      \
   GEN(JALR), GEN(LB), GEN(LH), GEN(LW), GEN(LBU), GEN(LD), GEN(LHU),           \
       GEN(ADDI), GEN(SLTI), GEN(SLTIU), GEN(XORI), GEN(ORI), GEN(ANDI),        \
       GEN(SLLI), GEN(SRLI), GEN(SRAI), GEN(ADDIW), GEN(SLLIW), GEN(SRLIW),     \
-      GEN(SRAIW)
+      GEN(SRAIW),                                                              \
+      GEN(FLW), GEN(FLD)
 
-#define MAKE_SFORMAT(GEN) GEN(SB), GEN(SH), GEN(SW), GEN(SD)
+#define MAKE_SFORMAT(GEN)                                                      \
+  GEN(SB), GEN(SH), GEN(SW), GEN(SD),                                          \
+      GEN(FSW), GEN(FSD)
 
 #define MAKE_BFORMAT(GEN)                                                      \
   GEN(BEQ), GEN(BNE), GEN(BLT), GEN(BGE), GEN(BLTU), GEN(BGEU)
@@ -30,7 +48,7 @@
 
 #define FOR_ENUM(x) x
 #define FOR_NAME(x)                                                            \
-  { LowInstType::x, #x }
+  { LowInstType::x, std::string(#x) }
 
 namespace nnvm::riscv {
 
@@ -90,16 +108,21 @@ enum LowInstType : uint64_t {
 
 static inline const char *getNameForInstType(uint64_t type) {
 
-  static std::unordered_map<uint64_t, const char *> typeToName = {
+  static std::unordered_map<uint64_t, std::string> typeToName = {
       MAKE_RFORMAT(FOR_NAME), MAKE_IFORMAT(FOR_NAME), MAKE_SFORMAT(FOR_NAME),
       MAKE_BFORMAT(FOR_NAME), MAKE_JFORMAT(FOR_NAME), MAKE_UFORMAT(FOR_NAME),
       MAKE_OTHER(FOR_NAME)};
 
+  // replace all underline to dot. e.g. FCVT_S_W -> FCVT.S.W
+  for (auto &[_, name] : typeToName) {
+    std::regex_replace(name.begin(), name.cbegin(), name.cend(), std::regex("_"), ".");
+  }
+
   if (!typeToName.count(type)) {
-    std::cerr << "Handling the operator:" << (uint64_t)type << "\n";
+    std::cerr << "Handling the operator:" << type << "\n";
     nnvm_unreachable("Not implemented yet");
   }
-  return typeToName[type];
+  return typeToName[type].c_str();
 }
 
 static inline LowInstType toIFormat(uint64_t type) {


### PR DESCRIPTION
Add float and double instructions without quad-precision and half-precision ones.